### PR TITLE
Add animated backend forecast visualizations

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,10 +3,11 @@
 import { useState } from "react"
 import { SearchBar } from "@/components/search-bar"
 import { WeatherDisplay } from "@/components/weather-display"
+import type { WeatherData } from "@/types/weather"
 import { Cloud, Sun } from "lucide-react"
 
 export default function Home() {
-  const [weatherData, setWeatherData] = useState<any>(null)
+  const [weatherData, setWeatherData] = useState<WeatherData | null>(null)
   const [loading, setLoading] = useState(false)
 
   const handleSearch = async (location: string, date: string) => {

--- a/components/animated-number.tsx
+++ b/components/animated-number.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+interface AnimatedNumberProps {
+  value: number
+  decimals?: number
+  durationMs?: number
+}
+
+export function AnimatedNumber({ value, decimals = 0, durationMs = 800 }: AnimatedNumberProps) {
+  const [displayValue, setDisplayValue] = useState(value)
+  const previousValue = useRef(value)
+
+  useEffect(() => {
+    const start = previousValue.current
+    const diff = value - start
+    const startTime = performance.now()
+    let frameId: number
+
+    const animate = (time: number) => {
+      const progress = Math.min((time - startTime) / durationMs, 1)
+      const easedProgress = 1 - Math.pow(1 - progress, 3)
+      setDisplayValue(start + diff * easedProgress)
+      if (progress < 1) {
+        frameId = requestAnimationFrame(animate)
+      }
+    }
+
+    frameId = requestAnimationFrame(animate)
+    previousValue.current = value
+
+    return () => cancelAnimationFrame(frameId)
+  }, [value, durationMs])
+
+  return <span>{displayValue.toFixed(decimals)}</span>
+}

--- a/components/backend-forecast-insights.tsx
+++ b/components/backend-forecast-insights.tsx
@@ -1,0 +1,246 @@
+"use client"
+
+import { Card } from "@/components/ui/card"
+import { AnimatedNumber } from "@/components/animated-number"
+import { Activity, Droplets, MapPin } from "lucide-react"
+import type { BackendSummary, ConditionRisk } from "@/types/weather"
+import {
+  ResponsiveContainer,
+  RadialBarChart,
+  RadialBar,
+  PolarAngleAxis,
+  BarChart,
+  CartesianGrid,
+  XAxis,
+  Tooltip,
+  Bar,
+  Cell,
+} from "recharts"
+
+interface BackendForecastInsightsProps {
+  summary: BackendSummary
+  riskScores?: ConditionRisk[]
+}
+
+const probabilityColors = ["#38bdf8", "#1e40af"]
+const precipitationColors = ["#22c55e", "#16a34a", "#15803d", "#0f766e", "#0ea5e9", "#1d4ed8"]
+const weightColors = ["#fb7185", "#f97316", "#facc15", "#34d399", "#38bdf8"]
+
+const formatPercent = (value: number) => `${(value * 100).toFixed(0)}%`
+
+export function BackendForecastInsights({ summary, riskScores }: BackendForecastInsightsProps) {
+  const probabilityPercent = Number((summary.ml_rain_probability.probability * 100).toFixed(1))
+
+  const precipitationModels = Object.entries(summary.ml_precipitation_mm.individual_predictions_mm).map(
+    ([model, value]) => ({
+      model: model.toUpperCase(),
+      value,
+    }),
+  )
+
+  const regressionWeights = Object.entries(summary.ml_precipitation_mm.ensemble_weights_reg).map(([model, value]) => ({
+    model: model.toUpperCase(),
+    value,
+  }))
+
+  const probabilityModels = Object.entries(summary.ml_rain_probability.individual_probabilities).map(([model, value]) => ({
+    model: model.toUpperCase(),
+    value,
+  }))
+
+  const classificationWeights = Object.entries(summary.ml_rain_probability.ensemble_weights_cls).map(([model, value]) => ({
+    model: model.toUpperCase(),
+    value,
+  }))
+
+  return (
+    <div className="space-y-4 md:space-y-6">
+      <Card className="p-4 md:p-6 bg-card/80 border-2 overflow-hidden">
+        <div className="flex flex-col gap-4 md:gap-6">
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <div>
+              <h3 className="text-lg md:text-xl font-semibold text-foreground">Machine learning forecast</h3>
+              <p className="text-sm text-muted-foreground">
+                Ensemble breakdown for {new Date(summary.prediction_for).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })}
+              </p>
+            </div>
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <MapPin className="w-4 h-4" />
+              <span>
+                {summary.location.lat.toFixed(2)}, {summary.location.lon.toFixed(2)}
+              </span>
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:gap-6 md:grid-cols-3">
+            <Card className="p-4 bg-primary/5 border-primary/40">
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-2">
+                  <Droplets className="w-5 h-5 text-primary" />
+                  <span className="text-sm font-medium text-primary">Ensemble precipitation</span>
+                </div>
+                <span className="text-xs uppercase tracking-wide text-primary/70">mm</span>
+              </div>
+              <div className="text-3xl font-semibold text-foreground">
+                <AnimatedNumber value={summary.ml_precipitation_mm.prediction_mm} decimals={1} />
+              </div>
+              <p className="text-xs text-muted-foreground mt-2">
+                ± <AnimatedNumber value={summary.ml_precipitation_mm.uncertainty_mm} decimals={1} /> mm (95% CI {summary.ml_precipitation_mm.confidence_interval_mm.lower.toFixed(1)} -
+                {" "}
+                {summary.ml_precipitation_mm.confidence_interval_mm.upper.toFixed(1)} mm)
+              </p>
+              <div className="mt-4 space-y-2">
+                {precipitationModels.map((model, index) => (
+                  <div key={model.model} className="space-y-1">
+                    <div className="flex items-center justify-between text-xs font-medium text-muted-foreground">
+                      <span>{model.model}</span>
+                      <span>{model.value.toFixed(1)} mm</span>
+                    </div>
+                    <div className="h-2 rounded-full bg-muted">
+                      <div
+                        className="h-full rounded-full transition-all duration-700"
+                        style={{
+                          width: `${Math.min(Math.max((model.value / Math.max(summary.ml_precipitation_mm.confidence_interval_mm.upper, 1)) * 100, 4), 100)}%`,
+                          backgroundColor: precipitationColors[index % precipitationColors.length],
+                        }}
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </Card>
+
+            <Card className="p-4 bg-secondary/5 border-secondary/40">
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-2">
+                  <Activity className="w-5 h-5 text-secondary" />
+                  <span className="text-sm font-medium text-secondary">Rain probability</span>
+                </div>
+                <span className="text-xs uppercase tracking-wide text-secondary/70">confidence</span>
+              </div>
+              <div className="h-36">
+                <ResponsiveContainer width="100%" height="100%">
+                  <RadialBarChart
+                    innerRadius="60%"
+                    data={[{ name: "probability", value: probabilityPercent, fill: probabilityColors[0] }]}
+                    startAngle={90}
+                    endAngle={-270}
+                  >
+                    <PolarAngleAxis type="number" domain={[0, 100]} tick={false} />
+                    <RadialBar dataKey="value" cornerRadius={8} background fill={probabilityColors[1]} animationDuration={800} />
+                  </RadialBarChart>
+                </ResponsiveContainer>
+              </div>
+              <div className="text-3xl font-semibold text-foreground text-center">
+                <AnimatedNumber value={probabilityPercent} decimals={1} />%
+              </div>
+              <p className="text-xs text-muted-foreground text-center mt-1 capitalize">
+                {summary.ml_rain_probability.confidence_level} confidence • ±{summary.ml_rain_probability.uncertainty.toFixed(2)}
+              </p>
+            </Card>
+
+            <Card className="p-4 bg-accent/5 border-accent/40">
+              <div className="flex items-center justify-between mb-3">
+                <span className="text-sm font-medium text-accent-foreground">Model agreement</span>
+                <span className="text-xs text-muted-foreground">classification</span>
+              </div>
+              <div className="space-y-3">
+                {probabilityModels.map((model) => (
+                  <div key={model.model} className="space-y-1">
+                    <div className="flex items-center justify-between text-xs font-medium text-muted-foreground">
+                      <span>{model.model}</span>
+                      <span>{formatPercent(model.value)}</span>
+                    </div>
+                    <div className="h-2 rounded-full bg-muted">
+                      <div
+                        className="h-full rounded-full bg-gradient-to-r from-accent to-primary transition-all duration-700"
+                        style={{ width: `${Math.max(model.value * 100, 4)}%` }}
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </Card>
+          </div>
+
+          <div className="grid gap-4 md:gap-6 md:grid-cols-2">
+            <Card className="p-4">
+              <h4 className="text-sm font-semibold text-foreground mb-4">Regression ensemble weights</h4>
+              <div className="h-60">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={regressionWeights}>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                    <XAxis dataKey="model" axisLine={false} tickLine={false} stroke="currentColor" />
+                    <Tooltip
+                      cursor={{ fill: "hsl(var(--muted) / 0.2)" }}
+                      contentStyle={{ background: "hsl(var(--card))", borderRadius: 12, border: "1px solid hsl(var(--border))" }}
+                      formatter={(value: number) => [`${(value * 100).toFixed(1)}%`, "Weight"]}
+                    />
+                    <Bar dataKey="value" radius={[6, 6, 0, 0]} animationDuration={700}>
+                      {regressionWeights.map((entry, index) => (
+                        <Cell key={entry.model} fill={precipitationColors[index % precipitationColors.length]} />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </Card>
+
+            <Card className="p-4">
+              <h4 className="text-sm font-semibold text-foreground mb-4">Classification ensemble weights</h4>
+              <div className="h-60">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={classificationWeights}>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                    <XAxis dataKey="model" axisLine={false} tickLine={false} stroke="currentColor" />
+                    <Tooltip
+                      cursor={{ fill: "hsl(var(--muted) / 0.2)" }}
+                      contentStyle={{ background: "hsl(var(--card))", borderRadius: 12, border: "1px solid hsl(var(--border))" }}
+                      formatter={(value: number) => [`${(value * 100).toFixed(1)}%`, "Weight"]}
+                    />
+                    <Bar dataKey="value" radius={[6, 6, 0, 0]} animationDuration={700}>
+                      {classificationWeights.map((entry, index) => (
+                        <Cell key={entry.model} fill={weightColors[index % weightColors.length]} />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </Card>
+          </div>
+        </div>
+      </Card>
+
+      {riskScores && riskScores.length > 0 && (
+        <Card className="p-4 md:p-6 bg-card/80 border-2">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-lg font-semibold text-foreground">Condition risk outlook</h3>
+            <span className="text-xs text-muted-foreground">Likelihood of challenging weather</span>
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            {riskScores.map((risk, index) => (
+              <div key={risk.id} className="p-3 rounded-xl border bg-gradient-to-r from-background via-card to-background">
+                <div className="flex items-center justify-between text-sm font-medium text-muted-foreground">
+                  <span className="capitalize">{risk.label}</span>
+                  <span className="text-foreground">
+                    <AnimatedNumber value={risk.probability * 100} decimals={0} />%
+                  </span>
+                </div>
+                <div className="h-2 mt-2 rounded-full bg-muted overflow-hidden">
+                  <div
+                    className="h-full rounded-full transition-all duration-700"
+                    style={{
+                      width: `${Math.max(risk.probability * 100, 4)}%`,
+                      backgroundImage: `linear-gradient(90deg, ${probabilityColors[0]}, ${precipitationColors[index % precipitationColors.length]})`,
+                    }}
+                  />
+                </div>
+                <p className="text-xs text-muted-foreground mt-2 leading-relaxed">{risk.description}</p>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/types/weather.ts
+++ b/types/weather.ts
@@ -1,0 +1,45 @@
+export interface BackendSummary {
+  prediction_for: string
+  location: {
+    lat: number
+    lon: number
+  }
+  ml_precipitation_mm: {
+    prediction_mm: number
+    individual_predictions_mm: Record<string, number>
+    uncertainty_mm: number
+    confidence_interval_mm: {
+      lower: number
+      upper: number
+    }
+    ensemble_weights_reg: Record<string, number>
+  }
+  ml_rain_probability: {
+    probability: number
+    individual_probabilities: Record<string, number>
+    uncertainty: number
+    confidence_level: string
+    ensemble_weights_cls: Record<string, number>
+  }
+}
+
+export interface ConditionRisk {
+  id: string
+  label: string
+  probability: number
+  description: string
+}
+
+export interface WeatherData {
+  location: string
+  temperature: number
+  condition: string
+  humidity: number
+  windSpeed: number
+  visibility: number
+  pressure: number
+  description: string
+  date?: string
+  backendSummary?: BackendSummary
+  riskScores?: ConditionRisk[]
+}


### PR DESCRIPTION
## Summary
- extend the weather API route to synthesize backend-style ensemble insights and condition risk scores alongside standard weather data
- introduce animated visual components to narrate the machine-learning precipitation and rain probability outputs, including charts and gauges
- wire the frontend to the new data model with reusable types and downloadable summaries that include backend analytics

## Testing
- pnpm lint *(fails: prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fc6178f48324bccfe64755cd55e7